### PR TITLE
Change DBHOST and DBUSER forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The sample is a simple Python Django application that connects to a PostgreSQL d
 
 The database connection information is specified via environment variables `DBHOST`, `DBPASS`, `DBUSER`, and `DBNAME`. This app always uses the default PostgreSQL port.
 
+**BREAKING CHANGE Oct 12 2020**: The `DBHOST` environment variable is expected to contain *only* the server name, not the full URL, which is constructed at run time (see azuresite/production.py). Similarly, `DBUSER` is expected to contain only the user name, not username@servername as before, because using the simpler `DBHOST` the code can also construct the correct login form at run time (again in azuresite/production.py), avoiding failures that arise when `DBUSER` lacks the @servername portion.  
+
 # Contributing
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/azuresite/production.py
+++ b/azuresite/production.py
@@ -1,4 +1,5 @@
 from .settings import *
+import os
 
 # Configure the domain name using the environment variable
 # that Azure automatically creates for us.
@@ -20,13 +21,17 @@ MIDDLEWARE = [
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'  
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
-# Configure Postgres database
-DATABASES = {                                                                    
-    'default': {                                                                 
-        'ENGINE': 'django.db.backends.postgresql',                               
-        'NAME': os.environ['DBNAME'],                                            
-        'HOST': os.environ['DBHOST'],                                            
-        'USER': os.environ['DBUSER'],                                            
-        'PASSWORD': os.environ['DBPASS']                                         
-    }                                                                            
+# DBHOST is only the server name, not the full URL
+hostname = os.environ['DBHOST']
+
+# Configure Postgres database; the full username is username@servername,
+# which we construct using the DBHOST value.
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.environ['DBNAME'],
+        'HOST': hostname + ".postgres.database.azure.com",
+        'USER': os.environ['DBUSER'] + "@" + hostname,
+        'PASSWORD': os.environ['DBPASS'] 
+    }
 }

--- a/azuresite/settings.py
+++ b/azuresite/settings.py
@@ -10,14 +10,15 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.1/ref/settings/
 """
 
-import os
+from pathlib import Path
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Build paths inside the project like this: BASE_DIR / 'subdir'.
+BASE_DIR = Path(__file__).resolve().parent.parent
 
 
 # Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
+# See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '-^rq(x*d--6_#635*j84d5(fz9@-3(9vdr_s$9+^@cw08dq(ja'
@@ -55,7 +56,7 @@ ROOT_URLCONF = 'azuresite.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [os.path.join(BASE_DIR, 'templates')],
+        'DIRS': [BASE_DIR / 'templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -77,7 +78,7 @@ WSGI_APPLICATION = 'azuresite.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'NAME': BASE_DIR / 'db.sqlite3',
     }
 }
 


### PR DESCRIPTION
Also use pathlib.Path instead of os.path in settings.py.

## Purpose
* Removes complexities and customer failures in the App Service tutorial caused by needing a username@servername form for the credentials given to Postgres. With this change, the required username form is created automatically from DBHOST and DBUSER, rather than having to be specified explicitly.
* Also changes DBHOST to be only the server name, not the full server URL, as the latter is easily constructed by appending the standard domain info for Postgres on Azure.

## Does this introduce a breaking change?
```
[X] Yes (explained in the updated README.md)
[ ] No
```

