### PR TITLE
Expand date time control by default

### DIFF
--- a/polls/admin.py
+++ b/polls/admin.py
@@ -9,7 +9,7 @@ class ChoiceInline(admin.TabularInline):
 class QuestionAdmin(admin.ModelAdmin):
     fieldsets = [
         (None,               {'fields': ['question_text']}),
-        ('Date information', {'fields': ['pub_date'], 'classes': ['collapse']}),
+        ('Date information', {'fields': ['pub_date']}),
     ]
     inlines = [ChoiceInline]
     list_display = ('question_text', 'pub_date', 'was_published_recently')


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Assume I'm a new developer who follows Azure tutorials to deploy this sample app, it is a little bit annoying that the first poll creation always failed because I didn't put date time info. The reason is simply that this control is collapsed by default.
Remove the css so that I can see date time by default when creating a new poll.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Just deploy this change again to the webapp, go to admin page and create a new poll.

## What to Check
Verify that the following are valid
* date and time section now expand by default.

## Other Information
<!-- Add any other helpful information that may be needed here. -->