### PR TITLE
Remove DJANGO_ENV in favor of WEBSITE_HOSTNAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,18 @@ author: cephalin
 
 # Django and PostgreSQL sample for Azure App Service
 
-This is a sample application that you can use to follow along with the tutorial at 
-[Build a Python and PostgreSQL web app in Azure App Service](https://docs.microsoft.com/azure/app-service/containers/tutorial-python-postgresql-app). 
+This is a sample application that you can use to follow along with the tutorial at [Build a Python and PostgreSQL web app in Azure App Service](https://docs.microsoft.com/azure/app-service/containers/tutorial-python-postgresql-app).
 
 The sample is a simple Python Django application that connects to a PostgreSQL database.
 
 The database connection information is specified via environment variables `DBHOST`, `DBPASS`, `DBUSER`, and `DBNAME`. This app always uses the default PostgreSQL port.
 
-**BREAKING CHANGE Oct 12 2020**: The `DBHOST` environment variable is expected to contain *only* the server name, not the full URL, which is constructed at run time (see azuresite/production.py). Similarly, `DBUSER` is expected to contain only the user name, not username@servername as before, because using the simpler `DBHOST` the code can also construct the correct login form at run time (again in azuresite/production.py), avoiding failures that arise when `DBUSER` lacks the @servername portion.  
+## Change log
 
-# Contributing
+- 27 Oct 2020: Possible breaking change: removed use of the `DJANGO_ENV` environment variable to switch between local and production settings. The code instead triggers the selection using the `WEBSITE_HOSTNAME` environment variable, which is defined when the code is running inside the the Azure App Service container. See manage.py and azuresite/wsgi.py.
+
+- 12 Oct 2020: **BREAKING CHANGE**: The `DBHOST` environment variable is expected to contain *only* the server name, not the full URL, which is constructed at run time (see azuresite/production.py). Similarly, `DBUSER` is expected to contain only the user name, not username@servername as before, because using the simpler `DBHOST` the code can also construct the correct login form at run time (again in azuresite/production.py), avoiding failures that arise when `DBUSER` lacks the @servername portion.  
+
+## Contributing
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ author: cephalin
 
 # Django and PostgreSQL sample for Azure App Service
 
-This is a sample application that you can use to follow along with the tutorial at [Build a Python and PostgreSQL web app in Azure App Service](https://docs.microsoft.com/azure/app-service/containers/tutorial-python-postgresql-app).
+This samples is a simple Django app that connects to a PostgreSQL database. The sample is used with the following tutorials:
 
-The sample is a simple Python Django application that connects to a PostgreSQL database.
+- [Deploy a Django web app with PostgreSQL in Azure App Service (Azure CLI)](https://docs.microsoft.com/azure/app-service/containers/tutorial-python-postgresql-app).
+- [Deploy a Django web app with PostgreSQL using the Azure portal](https://docs.microsoft.com/en-us/azure/developer/python/tutorial-python-postgresql-app-portal).
 
-The database connection information is specified via environment variables `DBHOST`, `DBPASS`, `DBUSER`, and `DBNAME`. This app always uses the default PostgreSQL port.
+When deployed to Azure App Service, the database connection information is specified via environment variables `DBHOST`, `DBPASS`, `DBUSER`, and `DBNAME`. This app always uses the default PostgreSQL port. See the tutorials for more information.
 
 ## Change log
 

--- a/azuresite/wsgi.py
+++ b/azuresite/wsgi.py
@@ -11,9 +11,9 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-if os.environ.get('DJANGO_ENV') == 'production':
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'azuresite.production')
-else:
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'azuresite.settings')    
+# If WEBSITE_HOSTNAME is defined as an environment variable, then we're running
+# on Azure App Service and should use the production settings in production.py.
+settings_module = "azuresite.production" if 'WEBSITE_HOSTNAME' in os.environ else 'azuresite.settings'
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', settings_module)
 
 application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -3,10 +3,10 @@ import os
 import sys
 
 if __name__ == '__main__':
-    if os.environ.get('DJANGO_ENV') == 'production':
-        os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'azuresite.production')
-    else:
-        os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'azuresite.settings')    
+    # If WEBSITE_HOSTNAME is defined as an environment variable, then we're running
+    # on Azure App Service and should use the production settings.
+    settings_module = "azuresite.production" if 'WEBSITE_HOSTNAME' in os.environ else 'azuresite.settings'
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', settings_module)
 
     try:
         from django.core.management import execute_from_command_line
@@ -16,4 +16,5 @@ if __name__ == '__main__':
             "available on your PYTHONPATH environment variable? Did you "
             "forget to activate a virtual environment?"
         ) from exc
+
     execute_from_command_line(sys.argv)


### PR DESCRIPTION
WEBSITE_HOSTNAME is automatically defined in the Azure App Service container, so it can be used to trigger loading of App Service production settings.

This change simplifies the steps in the associated tutorials.