### PR TITLE
Update tutorial links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@ author: cephalin
 
 # Django and PostgreSQL sample for Azure App Service
 
-This samples is a simple Django app that connects to a PostgreSQL database. The sample is used with the following tutorials:
-
-- [Deploy a Django web app with PostgreSQL in Azure App Service (Azure CLI)](https://docs.microsoft.com/azure/app-service/containers/tutorial-python-postgresql-app).
-- [Deploy a Django web app with PostgreSQL using the Azure portal](https://docs.microsoft.com/en-us/azure/developer/python/tutorial-python-postgresql-app-portal).
+This samples is a simple Django app that connects to a PostgreSQL database. The sample is used in the tutorial https://learn.microsoft.com/azure/postgresql/flexible-server/tutorial-django-app-service-postgres](Deploy Django app with App Service and Azure Database for PostgreSQL - Flexible Server).
 
 When deployed to Azure App Service, the database connection information is specified via environment variables `DBHOST`, `DBPASS`, `DBUSER`, and `DBNAME`. This app always uses the default PostgreSQL port. See the tutorials for more information.
 


### PR DESCRIPTION
This PR replaces the two tutorial links with a tutorial that does link to this repo.

The original first link went to a tutorial that uses a different app (https://github.com/Azure-Samples/msdocs-django-postgresql-sample-app) and the original second link 404ed.

Let me know if you're aware of other tutorials using this app.